### PR TITLE
Use "replace github.com/unravelin/null/v5 => github.com/unravelin/null" in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.24
 
 toolchain go1.24.0
 
+replace github.com/unravelin/null => github.com/unravelin/null/v5 v5.0.1
+
 require (
 	github.com/go-json-experiment/json v0.0.0-20250213060926-925ba3f173fa
 	github.com/golang/snappy v1.0.0
 	github.com/google/go-cmp v0.7.0
-	github.com/unravelin/null/v5 v5.0.1
+	github.com/unravelin/null v0.0.0-00010101000000-000000000000
 )
 
 require (

--- a/null/null.go
+++ b/null/null.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/philpearl/avro"
 	avrotime "github.com/philpearl/avro/time"
-	"github.com/unravelin/null/v5"
+	"github.com/unravelin/null"
 )
 
 // RegisterCodecs registers the codecs from this package and makes them

--- a/null/null_test.go
+++ b/null/null_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/philpearl/avro"
-	"github.com/unravelin/null/v5"
+	"github.com/unravelin/null"
 )
 
 func TestNullThings(t *testing.T) {


### PR DESCRIPTION
Without this, we cannot upgrade github.com/unravelin/core to use the latest and greatest version of the decoder:

```
$ go get -u github.com/philpearl/avro
go: github.com/unravelin/null/v5@v5.0.1 used for two different module paths (github.com/unravelin/null and github.com/unravelin/null/v5)
```

I'm open to us changing everything else to use github.com/unravelin/null/v5 as the module path. (There aren't too many cases and it's a fairly simple syntactic change.)